### PR TITLE
Move cairo_test dep requirement to dev-dependencies

### DIFF
--- a/campaigns/bad-accounts/bendy-signatures/Scarb.toml
+++ b/campaigns/bad-accounts/bendy-signatures/Scarb.toml
@@ -6,7 +6,9 @@ cairo-version = "2.7.0"
 [[target.starknet-contract]]
 
 [dependencies]
-cairo_test = "2.7.0"
 starknet = "2.7.0"
+
+[dev-dependencies]
+cairo_test = "2.7.0"
 
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest

--- a/campaigns/bad-accounts/orderless-hashing/Scarb.toml
+++ b/campaigns/bad-accounts/orderless-hashing/Scarb.toml
@@ -6,7 +6,9 @@ cairo-version = "2.7.0"
 [[target.starknet-contract]]
 
 [dependencies]
-cairo_test = "2.7.0"
 starknet = "2.7.0"
+
+[dev-dependencies]
+cairo_test = "2.7.0"
 
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest

--- a/campaigns/bad-accounts/stealing-souls/Scarb.toml
+++ b/campaigns/bad-accounts/stealing-souls/Scarb.toml
@@ -6,7 +6,9 @@ cairo-version = "2.7.0"
 [[target.starknet-contract]]
 
 [dependencies]
-cairo_test = "2.7.0"
 starknet = "2.7.0"
+
+[dev-dependencies]
+cairo_test = "2.7.0"
 
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest

--- a/campaigns/cairo-thinking/puzzling-pyramids/Scarb.toml
+++ b/campaigns/cairo-thinking/puzzling-pyramids/Scarb.toml
@@ -3,7 +3,7 @@ name = "src"
 version = "1.4.0"
 cairo-version = "2.7.0"
 
-[dependencies]
+[dev-dependencies]
 cairo_test = "2.7.0"
 
 [tool.NodeGuardians]

--- a/campaigns/cairo-thinking/racing-riverboats/Scarb.toml
+++ b/campaigns/cairo-thinking/racing-riverboats/Scarb.toml
@@ -3,7 +3,7 @@ name = "src"
 version = "1.4.0"
 cairo-version = "2.7.0"
 
-[dependencies]
+[dev-dependencies]
 cairo_test = "2.7.0"
 
 [tool.NodeGuardians]

--- a/campaigns/cairo-thinking/sparring-sorcerers/Scarb.toml
+++ b/campaigns/cairo-thinking/sparring-sorcerers/Scarb.toml
@@ -3,7 +3,7 @@ name = "src"
 version = "1.4.0"
 cairo-version = "2.7.0"
 
-[dependencies]
+[dev-dependencies]
 cairo_test = "2.7.0"
 
 [tool.NodeGuardians]

--- a/campaigns/standalone-quests/brainfuck/Scarb.toml
+++ b/campaigns/standalone-quests/brainfuck/Scarb.toml
@@ -4,8 +4,10 @@ version = "1.4.0"
 cairo-version = "2.7.0"
 
 [dependencies]
-cairo_test = "2.7.0"
 starknet = "2.7.0"
+
+[dev-dependencies]
+cairo_test = "2.7.0"
 
 [tool.NodeGuardians]
 part_1 = "Brainfuck Program"

--- a/campaigns/standalone-quests/calldata-spoofing/Scarb.toml
+++ b/campaigns/standalone-quests/calldata-spoofing/Scarb.toml
@@ -6,7 +6,9 @@ cairo-version = "2.7.0"
 [[target.starknet-contract]]
 
 [dependencies]
-cairo_test = "2.7.0"
 starknet = "2.7.0"
+
+[dev-dependencies]
+cairo_test = "2.7.0"
 
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest

--- a/campaigns/standalone-quests/starknet-storage-layout/Scarb.toml
+++ b/campaigns/standalone-quests/starknet-storage-layout/Scarb.toml
@@ -6,7 +6,9 @@ cairo-version = "2.7.0"
 [[target.starknet-contract]]
 
 [dependencies]
-cairo_test = "2.7.0"
 starknet = "2.7.0"
+
+[dev-dependencies]
+cairo_test = "2.7.0"
 
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest

--- a/campaigns/standalone-quests/unsafe-math/Scarb.toml
+++ b/campaigns/standalone-quests/unsafe-math/Scarb.toml
@@ -6,7 +6,9 @@ cairo-version = "2.7.0"
 [[target.starknet-contract]]
 
 [dependencies]
-cairo_test = "2.7.0"
 starknet = "2.7.0"
+
+[dev-dependencies]
+cairo_test = "2.7.0"
 
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest

--- a/campaigns/standalone-quests/vanity-address/Scarb.toml
+++ b/campaigns/standalone-quests/vanity-address/Scarb.toml
@@ -6,7 +6,9 @@ cairo-version = "2.7.0"
 [[target.starknet-contract]]
 
 [dependencies]
-cairo_test = "2.7.0"
 starknet = "2.7.0"
+
+[dev-dependencies]
+cairo_test = "2.7.0"
 
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest

--- a/campaigns/starting-cairo/build-tutorial-cairo/Scarb.toml
+++ b/campaigns/starting-cairo/build-tutorial-cairo/Scarb.toml
@@ -4,6 +4,9 @@ version = "1.3.0"
 cairo-version = "2.7.0"
 
 [dependencies]
+starknet = "2.7.0"
+
+[dev-dependencies]
 cairo_test = "2.7.0"
 
 [tool.NodeGuardians]

--- a/campaigns/starting-cairo/ctf-tutorial-cairo/Scarb.toml
+++ b/campaigns/starting-cairo/ctf-tutorial-cairo/Scarb.toml
@@ -6,7 +6,9 @@ cairo-version = "2.7.0"
 [[target.starknet-contract]]
 
 [dependencies]
-cairo_test = "2.7.0"
 starknet = "2.7.0"
+
+[dev-dependencies]
+cairo_test = "2.7.0"
 
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest


### PR DESCRIPTION
Hi!

It's recommended to leave the `cairo_test` dependency in `dev-dependencies` section, as it should not be used outside tests.
